### PR TITLE
Change 'packaging' to 'format'

### DIFF
--- a/draft-ietf-moq-catalogformat.md
+++ b/draft-ietf-moq-catalogformat.md
@@ -137,7 +137,7 @@ Table 1 provides an overview of all fields defined by this document.
 | Catalogs                | catalogs               | {{catalogs}}              |
 | Track namespace         | namespace              | {{tracknamespace}}        |
 | Track name              | name                   | {{trackname}}             |
-| Packaging               | packaging              | {{packaging}}             |
+| Format                  | format                 | {{format}}                |
 | Track label             | label                  | {{tracklabel}}            |
 | Render group            | renderGroup            | {{rendergroup}}           |
 | Alternate group         | altGroup               | {{altgroup}}              |
@@ -249,18 +249,13 @@ Location: TFC    Required: Yes   Json Type: String
 A string defining the name of the track. See section 2.3 of {{MoQTransport}}.
 Within the catalog, track names MUST be unique per namespace.
 
-### Packaging {#packaging}
+### Format {#format}
 Location: TF    Required: Yes   Json Type: String
 
-A string defining the type of payload encapsulation. Allowed values are strings
-as defined in Table 3.
-
-Table 3: Allowed packaging values
-
-| Name            |   Value   |      Draft       |
-|:================|:==========|:=================|
-| CMAF            | "cmaf"    | See [CMAF]     |
-| LOC             | "loc"     | See RFC XXXX     |
+A string defining the format of the track. Format may describe the packaging,
+serialization or encapsulation of the track contents. The allowed values
+of this field are defined by the application format utilizing this catalog
+specification.
 
 ### Track label {#tracklabel}
 Location: TF    Required: Optional   Json Type: String
@@ -446,7 +441,7 @@ time-aligned audio and video tracks.
   "streamingFormatVersion": "0.2",
   "commonTrackFields": {
      "namespace": "conference.example.com/conference123/alice",
-     "packaging": "loc",
+     "format": "loc",
      "renderGroup": 1
   },
   "tracks": [
@@ -485,7 +480,7 @@ supportsDeltaUpdates flag.
   "supportsDeltaUpdates": true,
   "commonTrackFields": {
      "renderGroup": 1,
-     "packaging": "loc"
+     "format": "loc"
   },
   "tracks":[
     {
@@ -559,7 +554,7 @@ express the track relationships.
   "commonTrackFields": {
      "namespace": "conference.example.com/conference123/alice",
      "renderGroup": 1,
-     "packaging": "loc"
+     "format": "loc"
   },
   "tracks":[
     {
@@ -661,7 +656,7 @@ tracks.
   "supportsDeltaUpdates": true,
   "commonTrackFields": {
      "namespace": "sports.example.com/games/08-08-23/12345",
-     "packaging": "cmaf",
+     "format": "cmaf",
      "renderGroup":1
   },
   "tracks": [
@@ -724,13 +719,13 @@ LOC packaged audio.
       "selectionParams":{"codec":"avc1.64001f","mimeType":"video/mp4",
       "width":1280,"height":720,"framerate":30,"bitrate":4952892},
       "initTrack":"init_video_720",
-      "packaging":"cmaf"
+      "format":"cmaf"
     },
     {
       "name": "audio",
       "selectionParams":{"codec":"opus","samplerate":48000,"channelConfig":"2",
       "bitrate":32000},
-      "packaging": "loc"
+      "format": "loc"
     }
    ]
 }
@@ -750,7 +745,7 @@ The data has been truncated for clarity.
   "streamingFormatVersion": "0.2",
   "commonTrackFields": {
      "namespace": "sports.example.com/games/08-08-23/12345",
-     "packaging": "cmaf",
+     "format": "cmaf",
      "renderGroup":1
   },
   "tracks": [
@@ -783,7 +778,7 @@ description.
   "streamingFormatVersion": "0.2",
   "commonTrackFields": {
      "namespace": "conference.example.com/conference123/alice",
-     "packaging": "loc",
+     "format": "loc",
      "renderGroup": 1
   },
   "tracks": [
@@ -921,8 +916,8 @@ Location: TC<br/>
 JSON Type: String<br/>
 Specification: [MoQCatalog]<br/>
 
-Descriptive Name: Packaging<br/>
-Field Name: packaging<br/>
+Descriptive Name: Format<br/>
+Field Name: format<br/>
 Required: yes<br/>
 Location: RT<br/>
 JSON Type: String<br/>


### PR DESCRIPTION
Replaces the packaging track attribute with a new field called 'format'.
This field supports broader uses cases outside media.
The values for the format string are defined by the application specification which is referencing this catalog format. 

Fixes #62 